### PR TITLE
Get composer.json relative to current file

### DIFF
--- a/src/Bootstraper.php
+++ b/src/Bootstraper.php
@@ -188,7 +188,7 @@ class Bootstraper {
 
     protected function getApimapMeta() {
         // NOTICE: Retrieve version of the package from the composer file
-        $pathFile = getcwd().'/vendor/forestadmin/forest-laravel/composer.json';
+        $pathFile = join(DIRECTORY_SEPARATOR, [__DIR__, '..', 'composer.json']);
         $composerFileContent = file_get_contents($pathFile);
         $composerFileContent = json_decode($composerFileContent);
         return [


### PR DESCRIPTION
Using the current working directory to identify the vendor directory is not safe as `artisan` may be executed from a directory other than the Laravel root.  Instead, use the `__DIR__` constant which identifies the directory of the file we’re currently in, and then work out where the `composer.json` should be from there.