### PR TITLE
[+] Installation - Auto-register the service provider on Laravel 5.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Auto-Discovery - Auto-register the service provider on Laravel 5.5+
 
 ## RELEASE 1.1.4 - 2017-05-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will then follow a 4-step process:
   ```bash
   composer require forestadmin/forest-laravel
   ```
-  Next, add the service provider to `config/app.php`
+  Next, if you're using Laravel 5.4 or below, add the service provider to `config/app.php`
 
   ```
   ForestAdmin\ForestLaravel\ForestServiceProvider::class,

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,12 @@
     "psr-4": {
       "ForestAdmin\\ForestLaravel\\" : "src"
     }
-  }
+  },
+  "extra": {
+        "laravel": {
+            "providers": [
+                "ForestAdmin\\ForestLaravel\\ForestServiceProvider"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
This will make the package work with [auto-discovery](https://github.com/laravel/framework/pull/19420) in Laravel 5.5