### PR TITLE
[+] Smart Search - Limit search to specific collection fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 ### Added
-- Smart Search - Limit search to specific collection fields.
-- Collection - Update the API to configurate a collection to be closer to the other lianas.
+- Custom Search - Developers can restrict the search to specific collection fields.
+
+### Changed
+- Smart Actions - Developers can customize Smart Actions with a new API (closer to the other lianas implementation).
 
 ### Changed
 - Readme - Add some documentation about configuration cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Smart Search - Limit search to specific colelction fields.
+
 ### Changed
 - Readme - Add some documentation about configuration cache.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Added
-- Smart Search - Limit search to specific colelction fields.
+- Smart Search - Limit search to specific collection fields.
 
 ### Changed
 - Readme - Add some documentation about configuration cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Smart Search - Limit search to specific collection fields.
+- Collection - Update the API to configurate a collection to be closer to the other lianas.
 
 ### Changed
 - Readme - Add some documentation about configuration cache.

--- a/src/Http/Services/ResourcesGetter.php
+++ b/src/Http/Services/ResourcesGetter.php
@@ -4,6 +4,7 @@ namespace ForestAdmin\ForestLaravel\Http\Services;
 
 use ForestAdmin\ForestLaravel\Http\Services\ConditionSetter;
 use ForestAdmin\ForestLaravel\Http\Services\SearchBuilder;
+use ForestAdmin\ForestLaravel\Logger;
 
 class ResourcesGetter {
     protected $tableNameModel;
@@ -37,6 +38,9 @@ class ResourcesGetter {
         $this->addOrderBy($query);
         $query->where(function($query) { $this->addSearch($query); });
         $query->where(function($query) { $this->addFilters($query); });
+
+        Logger::debug('[SearchBuilder] ');
+        Logger::debug(print_r($query->toSql(), true));
 
         $this->records = $query->get();
 

--- a/src/Http/Services/ResourcesGetter.php
+++ b/src/Http/Services/ResourcesGetter.php
@@ -4,7 +4,6 @@ namespace ForestAdmin\ForestLaravel\Http\Services;
 
 use ForestAdmin\ForestLaravel\Http\Services\ConditionSetter;
 use ForestAdmin\ForestLaravel\Http\Services\SearchBuilder;
-use ForestAdmin\ForestLaravel\Logger;
 
 class ResourcesGetter {
     protected $tableNameModel;

--- a/src/Http/Services/ResourcesGetter.php
+++ b/src/Http/Services/ResourcesGetter.php
@@ -39,9 +39,6 @@ class ResourcesGetter {
         $query->where(function($query) { $this->addSearch($query); });
         $query->where(function($query) { $this->addFilters($query); });
 
-        Logger::debug('[SearchBuilder] ');
-        Logger::debug(print_r($query->toSql(), true));
-
         $this->records = $query->get();
 
         $queryCount = $this->model->select($this->tableNameModel.'.*');

--- a/src/Http/Services/SearchBuilder.php
+++ b/src/Http/Services/SearchBuilder.php
@@ -4,12 +4,14 @@ namespace ForestAdmin\ForestLaravel\Http\Services;
 
 use ForestAdmin\ForestLaravel\Bootstraper;
 use ForestAdmin\ForestLaravel\Database;
+use Illuminate\Support\Facades\Config;
 
 class SearchBuilder {
     protected $collectionSchema;
     protected $tableNameModel;
     protected $fieldTableNames;
     protected $params;
+    protected $searchFields;
 
     public function __construct($query, $collectionSchema, $tableNameModel,
       $fieldTableNames, $params) {
@@ -18,6 +20,41 @@ class SearchBuilder {
         $this->tableNameModel = $tableNameModel;
         $this->fieldTableNames = $fieldTableNames;
         $this->params = $params;
+
+        $collectionName = $collectionSchema->getName();
+        $config = Config::get('forest.collection');
+
+        if (array_key_exists($collectionName, $config)) {
+            $collectionConfig = $config[$collectionName];
+
+            if (array_key_exists('search_fields', $collectionConfig)) {
+                $this->searchFields =
+                    $this->processSearchFieldsConfig($collectionConfig['search_fields']);
+            }
+        }
+    }
+
+    private function processSearchFieldsConfig($searchFieldsConfig) {
+        $searchFields = array_reduce($searchFieldsConfig, function ($carry, $item) {
+            $fields = explode('.', $item);
+            $count = count($fields);
+
+            if ($count == 1) {
+                if (!property_exists($carry, 'default')) {
+                    $carry->default = array();
+                }
+                array_push($carry->default, $fields[0]);
+            } else if ($count == 2) {
+                if (!property_exists($carry, $fields[0])) {
+                    $carry->{$fields[0]} = array();
+                }
+                array_push($carry->{$fields[0]}, $fields[1]);
+            }
+
+            return $carry;
+        }, (object)array());
+
+        return $searchFields;
     }
 
     public function perform() {
@@ -25,20 +62,23 @@ class SearchBuilder {
         if ($this->params->search) {
             foreach($this->collectionSchema->getFields() as $field) {
                 if ($field->isAttribute()) {
-                    // TODO: Ignore Smart field.
-                    // TODO: Ignore integration field.
-                    // TODO: Support enums in the search
-                    if ($field->getType() === 'Number' &&
-                      intval($this->params->search) !== 0) {
-                        $this->query->orWhere($this->tableNameModel.'.'.
-                          $field->getField(), intval($this->params->search));
-                    } else if ($field->getType() === 'String') {
-                        $this->query->orWhereRaw('LOWER('.$s.
-                          $this->tableNameModel.$s.'.'.$s.$field->getField().
-                          $s.') LIKE LOWER(\'%'.$this->params->search.'%\')');
+                    if ($this->isSearchableField($field->getField())) {
+                        // TODO: Ignore Smart field.
+                        // TODO: Ignore integration field.
+                        // TODO: Support enums in the search
+                        if ($field->getType() === 'Number' &&
+                          intval($this->params->search) !== 0) {
+                            $this->query->orWhere($this->tableNameModel.'.'.
+                              $field->getField(), intval($this->params->search));
+                        } else if ($field->getType() === 'String') {
+                            $this->query->orWhereRaw('LOWER('.$s.
+                              $this->tableNameModel.$s.'.'.$s.$field->getField().
+                              $s.') LIKE LOWER(\'%'.$this->params->search.'%\')');
+                        }
                     }
                 } else if ($field->isTypeToOne() &&
                   (int)$this->params->searchExtended) {
+
                     $modelAssociation = $this->getCollectionSchema(
                       $field->getReferencedModelName());
                     $tableNameAssociation = SchemaUtils::findResource(
@@ -48,28 +88,42 @@ class SearchBuilder {
                     // NOTICE: Prevent errors on search if the modelAssociation
                     //         is not found.
                     if ($modelAssociation) {
-                      foreach($modelAssociation->getFields() as
-                        $fieldAssociation) {
-                          if ($fieldAssociation->isAttribute()) {
-                              if ($fieldAssociation->getType() === 'Number' &&
-                                intval($this->params->search) !== 0) {
-                                  $this->query->orWhere($tableAssociation.'.'.
+                        foreach($modelAssociation->getFields() as $fieldAssociation) {
+                            if (
+                                $this->isSearchableField(
                                     $fieldAssociation->getField(),
-                                    intval($this->params->search));
-                              } else if ($fieldAssociation->getType() ===
-                                'String') {
-                                  $this->query->orWhereRaw('LOWER('.$s.
-                                    $tableAssociation.$s.'.'.$s.
-                                    $fieldAssociation->getField().$s.
-                                    ') LIKE LOWER(\'%'.$this->params->search.
-                                    '%\')');
-                              }
-                          }
-                      }
+                                    $tableNameAssociation
+                                )
+                            ) {
+                                if ($fieldAssociation->isAttribute()) {
+                                    if ($fieldAssociation->getType() === 'Number' &&
+                                    intval($this->params->search) !== 0) {
+                                        $this->query->orWhere($tableAssociation.'.'.
+                                        $fieldAssociation->getField(),
+                                        intval($this->params->search));
+                                    } else if ($fieldAssociation->getType() ===
+                                    'String') {
+                                        $this->query->orWhereRaw('LOWER('.$s.
+                                        $tableAssociation.$s.'.'.$s.
+                                        $fieldAssociation->getField().$s.
+                                        ') LIKE LOWER(\'%'.$this->params->search.
+                                        '%\')');
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+
+    private function isSearchableField($fieldName, $table = 'default') {
+        if (!isset($this->searchFields)) {
+            return true;
+        }
+
+        return in_array($fieldName, $this->searchFields->{$table});
     }
 
     // TODO: Factorise this code (duplicated in ApplicationController)

--- a/src/Http/Services/SearchBuilder.php
+++ b/src/Http/Services/SearchBuilder.php
@@ -78,7 +78,6 @@ class SearchBuilder {
                     }
                 } else if ($field->isTypeToOne() &&
                   (int)$this->params->searchExtended) {
-
                     $modelAssociation = $this->getCollectionSchema(
                       $field->getReferencedModelName());
                     $tableNameAssociation = SchemaUtils::findResource(

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -62,8 +62,8 @@ class Collection {
                 if (!is_null($collectionActions)) {
                     $actions = $collectionActions;
                 }
-                // TODO: Remove nameOld attribute once the lianas versions older than 0.1.4 are
-                //       minority.
+            // TODO: Remove nameOld attribute once the lianas versions older than 0.1.4 are
+            //       minority.
             } else if (array_key_exists($collectionNameOld, $oldForestLianaApiActions)) {
                 Logger::warning('DEPRECATION WARNING: Collection names are now based on the '.
                     'models names. Please rename the collection "'.$collectionNameOld.'" of your '.

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -41,32 +41,59 @@ class Collection {
 
     public function setActions() {
         $this->actions = array();
-        $actions = Config::get('forest.actions');
         $collectionName = $this->getName();
         $collectionNameOld = $this->getNameOld();
+        $collectionActions = $this->getActionsFromConfig($collectionName, $collectionNameOld);
 
-        if (!is_null($actions)) {
-            if (array_key_exists($collectionName, $actions)) {
-                $collectionActions = $actions[$collectionName];
+        if (!is_null($collectionActions)) {
+            foreach($collectionActions as $action) {
+                $this->actions[] = new Action($this, $action);
+            }
+        }
+    }
+
+    private function getActionsFromConfig($collectionName, $collectionNameOld) {
+        $actions = null;
+        $oldForestLianaApiActions = Config::get('forest.actions');
+
+        if (!is_null($oldForestLianaApiActions)) {
+            if (array_key_exists($collectionName, $oldForestLianaApiActions)) {
+                $collectionActions = $oldForestLianaApiActions[$collectionName];
                 if (!is_null($collectionActions)) {
-                    foreach($collectionActions as $action) {
-                        $this->actions[] = new Action($this, $action);
-                    }
+                    $actions = $collectionActions;
                 }
-            // TODO: Remove nameOld attribute once the lianas versions older than 0.1.4 are
-            //       minority.
-            } else if (array_key_exists($collectionNameOld, $actions)) {
+                // TODO: Remove nameOld attribute once the lianas versions older than 0.1.4 are
+                //       minority.
+            } else if (array_key_exists($collectionNameOld, $oldForestLianaApiActions)) {
                 Logger::warning('DEPRECATION WARNING: Collection names are now based on the '.
-                  'models names. Please rename the collection "'.$collectionNameOld.'" of your '.
-                  'Forest customisation in "'.$collectionName.'".');
-                $collectionActions = $actions[$collectionNameOld];
+                    'models names. Please rename the collection "'.$collectionNameOld.'" of your '.
+                    'Forest customisation in "'.$collectionName.'".');
+                $collectionActions = $oldForestLianaApiActions[$collectionNameOld];
                 if (!is_null($collectionActions)) {
-                    foreach($collectionActions as $action) {
-                        $this->actions[] = new Action($this, $action);
+                    $actions = $collectionActions;
+                }
+            }
+        }
+
+        $collectionsConfig = Config::get('forest.collection');
+
+        if (!is_null($collectionsConfig) && array_key_exists($collectionName, $collectionsConfig)) {
+            $collectionConfig = $collectionsConfig[$collectionName];
+
+            if (!is_null($collectionConfig) && array_key_exists('actions', $collectionConfig)) {
+                $collectionActions = $collectionConfig['actions'];
+
+                if (!is_null($collectionActions)) {
+                    if (is_null($actions)) {
+                        $actions = $collectionActions;
+                    } else {
+                        $actions = array_merge($actions, $collectionActions);
                     }
                 }
             }
         }
+
+        return $actions;
     }
 
     public function getActions() {


### PR DESCRIPTION
To configure a collection:
```
return [
  'secret_key' => '7a3049f8cd14e719c219e6d75e2a7715eef38bf6ec4be2ffc774a3374c9196a8',
  'auth_key' => 'l8oeFltNrdrbq6pPeEGzxbG47h2qCK46',
  'models_path' => 'app',
  'url' => 'http://localhost:3001',
  'debug_mode' => true,
  'collection' => [
    'AppPost' => [
      'search_fields' => ['id', 'title', 'users.password'],
    ],
    'AppUser' => [
      'actions' => [
        ['name' => 'unban']
      ]
    ]
  ]
];
```

Compared to before:
```
return [
  'secret_key' => '7a3049f8cd14e719c219e6d75e2a7715eef38bf6ec4be2ffc774a3374c9196a8',
  'auth_key' => 'l8oeFltNrdrbq6pPeEGzxbG47h2qCK46',
  'models_path' => 'app',
  'url' => 'http://localhost:3001',
  'debug_mode' => true,
  'actions' => [
    'AppUser' => [
      ['name' => 'ban']
    ]
  ]
];
```

The old way is still working though.

To create a smart action, old fashion:
https://gist.github.com/arnaudbesnier/9d10918516b9c6f15ae56e76446aa9cd#file-forestsmartactionlaravel-php

Laravel 5.5+:
https://gist.github.com/ArnaudValensi/3a5e50bc50a214f631e8e6e25aedd881